### PR TITLE
RxJava 1.2 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # RxAnimations
 
+[![Download](https://api.bintray.com/packages/0ximdigital/RxAnimationsRepo/RxAnimations/images/download.svg) ](https://bintray.com/0ximdigital/RxAnimationsRepo/RxAnimations/_latestVersion)
+[![API](https://img.shields.io/badge/API-15%2B-blue.svg?style=flat)](https://android-arsenal.com/api?level=15)
+
 RxAnimations is a library with the main goal to make android animations more solid and cohesive.
 
 
@@ -7,12 +10,10 @@ Download
 --------
 
 ```groovy
-  compile 'oxim.digital:rxanim:0.8.1'
+  compile 'oxim.digital:rxanim:0.8.2'
     
   compile 'io.reactivex:rxandroid:1.2.1'
 ```
-
-[ ![Download](https://api.bintray.com/packages/0ximdigital/RxAnimationsRepo/RxAnimations/images/download.svg) ](https://bintray.com/0ximdigital/RxAnimationsRepo/RxAnimations/_latestVersion)
 
 RxAnimations library is so far only compatible with rxJava 1.  
 Port for the RxJava2 support is to be expected soon.  


### PR DESCRIPTION
Recently, RxJava 1.2.0 has been released and they've made some backward-incompatible changes related to Completables, specifically:

- CompletableSubscriber -> rx.CompletableSubscriber
- CompletableOnSubscribe -> rx.Completable.OnSubscribe

After upgrading to RxJava 1.2, I'm getting the following gradle build issues on :

```
RxValueAnimator.from(myValueAnimator, animator ->{
              ...
 });
```
Error:(347, 24) error: cannot access CompletableOnSubscribe class file for rx.Completable$CompletableOnSubscribe not found